### PR TITLE
Disable bot from responding to everyone/all mentions

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -65,6 +65,9 @@ export default {
       model = options.model;
     } else {
       message = interaction.options.getString("message");
+      if (message.includes("@everyone") || message.includes("<@") || message.includes("@here")){
+        return; 
+      }
       model = interaction.options.getString("model");
     }
 


### PR DESCRIPTION
This bot sends a message every time 'everyone' or 'here' mentions are made in a channel. We want to disable this. Better to explicitly call the bot, as other bots are called. 